### PR TITLE
TRITON-2406 AdminUI should expose billing_tag field for packages TRITON-2407 AdminUI can't set package fields to empty string

### DIFF
--- a/less/package.less
+++ b/less/package.less
@@ -6,6 +6,7 @@
 
 /*
  * Copyright 2019 Joyent, Inc.
+ * Copyright 2023 Spearhead Systems SRL.
  */
 
 #page-package {
@@ -108,6 +109,15 @@
     line-height: 1.5em;
   }
 
+  .billing-tag {
+    strong {
+      vertical-align: top;
+    }
+
+    .value {
+      white-space: pre-wrap;
+    }
+  }
 
   .owners {
     display: inline-block;

--- a/less/package.less
+++ b/less/package.less
@@ -84,7 +84,7 @@
   form .package-owners .add-owner-entry { clear: both; margin-left: 180px;}
   form .disks .add-disk-entry { clear: both; margin-left: 180px; }
 
-  .owner, .description, .billing-id, .memory, .quota, .vcpus, .swap, .max-processes, .cpu-cap, .io-priority, .brand, .flexible-disk, .disk-size {
+  .owner, .description, .billing-id, .billing-tag, .memory, .quota, .vcpus, .swap, .max-processes, .cpu-cap, .io-priority, .brand, .flexible-disk, .disk-size {
     .widget-content;
 
     strong {

--- a/lib/packages.js
+++ b/lib/packages.js
@@ -103,7 +103,8 @@ module.exports.update = function (req, res, next) {
 
         var changes = req.body;
         for (var k in req.body) {
-            if (typeof (changes[k]) === 'string' && changes[k].length === 0) {
+            if (typeof (changes[k]) === 'string' && changes[k] === pkg[k]) {
+                // we only delete if we know there wasn't any change
                 delete changes[k];
             }
         }

--- a/lib/packages.js
+++ b/lib/packages.js
@@ -6,6 +6,7 @@
 
 /*
  * Copyright 2019 Joyent, Inc.
+ * Copyright 2023 Spearhead Systems SRL.
  */
 
 var _ = require('underscore');

--- a/lib/packages.js
+++ b/lib/packages.js
@@ -104,9 +104,16 @@ module.exports.update = function (req, res, next) {
 
         var changes = req.body;
         for (var k in req.body) {
-            if (typeof (changes[k]) === 'string' && changes[k] === pkg[k]) {
+            if (typeof (changes[k]) === 'string') {
+                // we want to remove empty strings, so tell PAPI it's null
+                if (changes[k] === '') {
+                    changes[k] = null;
+                }
+
                 // we only delete if we know there wasn't any change
-                delete changes[k];
+                if (changes[k] === pkg[k]) {
+                    delete changes[k];
+                }
             }
         }
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "MNX Cloud (mnx.io)",
   "name": "adminui",
   "description": "Triton Operations Portal",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "repository": {
     "type": "git",

--- a/www/js/tpl/package.hbs
+++ b/www/js/tpl/package.hbs
@@ -6,6 +6,7 @@
 
 <!--
     Copyright 2019 Joyent, Inc.
+    Copyright 2023 Spearhead Systems SRL.
 -->
 
 <div class="page-header">

--- a/www/js/tpl/package.hbs
+++ b/www/js/tpl/package.hbs
@@ -127,6 +127,13 @@
   {{/if}}
   {{/ifeq}}
 
+  {{#if billing_tag}}
+  <div class="billing-tag">
+    <strong>Billing Tag</strong>
+    <div class="value">{{billing_tag}}</div>
+  </div>
+  {{/if}}
+
   <section class="networks">
     <h3>Networks</h3>
     <div class="networks-list"></div>

--- a/www/js/tpl/packages-form.hbs
+++ b/www/js/tpl/packages-form.hbs
@@ -6,6 +6,7 @@
 
 <!--
     Copyright 2019 Joyent, Inc.
+    Copyright 2023 Spearhead Systems SRL.
 -->
 
 <div class="row">
@@ -268,12 +269,8 @@
 
       <div class="form-group">
         <label class="control-label col-sm-4" for="package-name">Billing Tag</label>
-        <div class="controls col-sm-6">
-          <input type="text"
-                 value="{{billing_tag}}"
-                 id="package-billing-tag"
-                 name="billing_tag"
-                 class="form-control col-sm-8">
+        <div class="controls col-sm-8">
+          <textarea class="form-control" rows="3" class="span4" name="billing_tag">{{billing_tag}}</textarea>
           <p class="help-block">
             <a data-toggle="tooltip" data-placement="bottom" data-trigger="hover"
               title="Arbitrary tag that can be used by ops for billing purposes; it has no intrinsic meaning to Triton.">

--- a/www/js/tpl/packages-form.hbs
+++ b/www/js/tpl/packages-form.hbs
@@ -267,6 +267,23 @@
       {{/unless}}
 
       <div class="form-group">
+        <label class="control-label col-sm-4" for="package-name">Billing Tag</label>
+        <div class="controls col-sm-6">
+          <input type="text"
+                 value="{{billing_tag}}"
+                 id="package-billing-tag"
+                 name="billing_tag"
+                 class="form-control col-sm-8">
+          <p class="help-block">
+            <a data-toggle="tooltip" data-placement="bottom" data-trigger="hover"
+              title="Arbitrary tag that can be used by ops for billing purposes; it has no intrinsic meaning to Triton.">
+              What is this?
+            </a>
+          </p>
+        </div>
+      </div>
+
+      <div class="form-group">
         <div class="col-sm-offset-4 col-sm-8">
           <div class="checkbox">
             <label><input type="checkbox" {{#if active}}checked{{/if}} name="active"> Activate Package</label>


### PR DESCRIPTION
PAPI has an [optional "billing_tag" field](https://github.com/TritonDataCenter/sdc-papi/blob/master/docs/index.md#package-billing_tag) that is currently only accessible from the CLI. This change adds support for creating a package with billing tag text, and editing billing tags in packages later on.

On the package creation screen, new billing-tag field:
![Capture](https://github.com/TritonDataCenter/sdc-adminui/assets/144988/4533687b-e190-4bd1-9f6c-41b9762b0372)

When viewing, it only displays if there is text in the billing tag. It falls under the "Optional Settings" heading:
![Capture2](https://github.com/TritonDataCenter/sdc-adminui/assets/144988/4a988e04-9127-4a95-b1f9-7fdfd5701a5c)

When editing:
![Capture3](https://github.com/TritonDataCenter/sdc-adminui/assets/144988/ff01f613-731e-43a4-8244-1bff5257a625)

It also fixes an annoying problem with the package update page (when you click "Modify Package" while viewing an existing package; _why is there no URL for this waaaargh_ 😜), which makes it impossible to delete a string. For example, if a description field contains the text "foo", and you'd rather it was blank, deleting "foo" in the package update page and saving the package won't do what you expect: the "foo" remains. This broken behaviour, and the fix in this patch, has been verified by checking sdc-papi /packages/\<uuid\> from the CLI.